### PR TITLE
FEAT: logging 모듈 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 **이름** 이채연<br>
 **전공/학년** 소프트웨어학부 3학년<br>
 **파트** 백엔드<br><br>
-### 4주차 CRUD<br>
+### 6주차 AWS EC2<br>
+로그 파일 캡쳐본<br>
+**server.log**<br>
+![server log](https://github.com/user-attachments/assets/6bc903d1-7344-495c-933a-6a102eba0c53)
+<br>
+**errors.log**<br>
+![errors log](https://github.com/user-attachments/assets/fe128a11-f61c-4b25-ae45-922ed2e472eb)
+<br><br>
+### 5주차 CRUD<br>
 포스트맨 실행화면<br>
 **특정 게시물에 포함된 모든 comment 조회**<br>
 ![image](https://github.com/user-attachments/assets/ce69c644-7bc1-4c66-bda2-1392c8103004)

--- a/likelion13/.gitignore
+++ b/likelion13/.gitignore
@@ -174,3 +174,6 @@ cython_debug/
 # End of https://www.toptal.com/developers/gitignore/api/django
 
 secrets.json
+#
+server.log
+errors.log

--- a/likelion13/config/middleware.py
+++ b/likelion13/config/middleware.py
@@ -1,0 +1,12 @@
+import logging
+#모든 http 요청을 로깅하는 미들웨어 클래스
+logger = logging.getLogger('custom.http')
+
+class RequestLoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        logger.info(f"{request.method} {request.get_full_path()}")
+        response = self.get_response(request)
+        return response

--- a/likelion13/config/settings.py
+++ b/likelion13/config/settings.py
@@ -39,7 +39,7 @@ SECRET_KEY = get_secret("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -59,12 +59,13 @@ PROJECT_APPS = [
 ]
 
 THIRD_PARTY_APPS = [
-
+    "corsheaders",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + PROJECT_APPS + THIRD_PARTY_APPS
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware', # 반드시 가장 위쪽에 추가
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -72,6 +73,19 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+# 인증 관련 요청(쿠키, 세션 등)을 허용
+# 예를 들어 브라우저가 백엔드 서버로 쿠키를 전송하거나, 백엔드에서 쿠키를 응답으로 보낼 수 있음
+CORS_ALLOW_CREDENTIALS = True
+
+# 서버로 요청 보낼 수 있는 도메인들 정의
+# 여기에서의 localhost는 EC2 인스턴스의 로컬환경이 아니라 프론트엔드 개발 로컬 환경 의미
+# 3000 포트는 프론트엔드 React 애플리케이션의 포트 번호
+# 추후 프론트엔드에서 웹 페이지 배포 후 도메인 매핑했다면 해당 도메인 추가 필요
+CORS_ALLOWED_ORIGINS = [ 
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
 ]
 
 ROOT_URLCONF = 'config.urls'

--- a/likelion13/config/settings.py
+++ b/likelion13/config/settings.py
@@ -70,6 +70,7 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     # 'django.middleware.csrf.CsrfViewMiddleware',
+    'config.middleware.RequestLoggingMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -162,3 +163,48 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'accounts.User'
+
+#django logging 설정
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+
+    'formatters': {   # 로그 메시지의 형식을 정의
+        'verbose': {  # 시간, 레벨, 메시지 정보 포함 (메시지에 url 포함)
+            'format': '[{asctime}] {levelname} {message}',
+            'style': '{',
+        },
+    },
+
+    'handlers': {  # 로그를 어디로 출력할지 정의
+        'file': {  # 일반 로그: server.log
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'server.log'),
+            'formatter': 'verbose',
+            'level': 'INFO',
+        },
+        'error_file': {  # 에러 로그: errors.log
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'errors.log'),
+            'formatter': 'verbose',
+            'level': 'WARNING',  # WARNING, ERROR, CRITICAL 레벨 기록
+        },
+    },
+
+    'loggers': { # 실제 로깅을 수행하는 로거 정의
+        # HTTP 요청을 기록하는 로거
+        # 미들웨어에서 사용
+        'custom.http': {  
+            'handlers': ['file', 'error_file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        # Django가 잡아주는 에러
+        # 500 에러, 404 에러, CSRF 실패 등 서버 에러 자동 기록
+        'django.request': {  
+            'handlers': ['file', 'error_file'],
+            'level': 'WARNING',
+            'propagate': False,
+        },
+    }
+}

--- a/likelion13/poetry.lock
+++ b/likelion13/poetry.lock
@@ -37,6 +37,22 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.7.0"
+description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_cors_headers-4.7.0-py3-none-any.whl", hash = "sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070"},
+    {file = "django_cors_headers-4.7.0.tar.gz", hash = "sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b"},
+]
+
+[package.dependencies]
+asgiref = ">=3.6"
+django = ">=4.2"
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 description = "A non-validating SQL parser."
@@ -68,4 +84,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "4a0b882f3c9e66118d03cade1f7382fdaa86736e3069c01c3baa41b15bc73371"
+content-hash = "033975729e8f7e03ae35727f7f3dbbbf1e37e0c542ad9c52988726c581253dc1"

--- a/likelion13/pyproject.toml
+++ b/likelion13/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "django (>=5.1.7,<6.0.0)"
+    "django (>=5.1.7,<6.0.0)",
+    "django-cors-headers (>=4.7.0,<5.0.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## 개요 (Summary)
- CORS 허용 도메인 추가
- HTTP 요청 및 에러에 대한 로깅 기능 추가

## 변경 사항 (Changes)
- CORS 허용 도메인에 프론트엔드 포트(3000) 추가
- 사용자 정의 미들웨어로 HTTP 요청 로깅
- Django 로깅 설정: WARNING 이상 로그는 `errors.log`에 기록
- 로그 파일 '.gitignore`에 추가